### PR TITLE
Update references after renaming

### DIFF
--- a/releng/com.incquerylabs.examples.cps.rcpapplication.headless.product/app_headless.product
+++ b/releng/com.incquerylabs.examples.cps.rcpapplication.headless.product/app_headless.product
@@ -95,6 +95,7 @@
       <plugin id="org.eclipse.viatra.examples.cps.xform.m2m.incr.expl"/>
       <plugin id="org.eclipse.viatra.examples.cps.xform.m2m.incr.qrt"/>
       <plugin id="org.eclipse.viatra.examples.cps.xform.m2m.incr.viatra"/>
+      <plugin id="org.eclipse.viatra.examples.cps.xform.m2m.launcher"/>
       <plugin id="org.eclipse.viatra.examples.cps.xform.m2m.tests"/>
       <plugin id="org.eclipse.viatra.examples.cps.xform.m2m.util"/>
       <plugin id="org.eclipse.viatra.examples.cps.xform.m2t"/>

--- a/releng/com.incquerylabs.examples.cps.rcpapplication.headless/META-INF/MANIFEST.MF
+++ b/releng/com.incquerylabs.examples.cps.rcpapplication.headless/META-INF/MANIFEST.MF
@@ -10,6 +10,6 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.viatra.examples.cps.tests.util,
  org.apache.log4j;bundle-version="1.2.15",
  org.eclipse.xtend.lib;bundle-version="2.9.0",
- org.eclipse.viatra.examples.cps.xform.m2m.tests;bundle-version="0.1.0",
+ org.eclipse.viatra.examples.cps.xform.m2m.launcher;bundle-version="0.1.0",
  eu.mondo.sam.bundle;bundle-version="0.1.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/releng/com.incquerylabs.examples.cps.rcpapplication.headless/src/com/incquerylabs/examples/cps/rcpapplication/headless/Application.xtend
+++ b/releng/com.incquerylabs.examples.cps.rcpapplication.headless/src/com/incquerylabs/examples/cps/rcpapplication/headless/Application.xtend
@@ -29,7 +29,7 @@ import org.apache.log4j.Logger
 import org.apache.log4j.PatternLayout
 import org.eclipse.equinox.app.IApplication
 import org.eclipse.equinox.app.IApplicationContext
-import org.eclipse.viatra.examples.cps.xform.m2m.tests.wrappers.TransformationType
+import org.eclipse.viatra.examples.cps.xform.m2m.launcher.TransformationType
 import org.eclipse.xtend.lib.annotations.Data
 
 import static eu.mondo.sam.core.metrics.MemoryMetric.*

--- a/tests/com.incquerylabs.examples.cps.performance.tests/META-INF/MANIFEST.MF
+++ b/tests/com.incquerylabs.examples.cps.performance.tests/META-INF/MANIFEST.MF
@@ -25,6 +25,7 @@ Require-Bundle: org.eclipse.xtend.lib,
  org.eclipse.viatra.query.runtime.base.itc;bundle-version="[1.2.0,2.0.0)",
  eu.mondo.sam.bundle;bundle-version="0.1.0",
  org.eclipse.viatra.query.testing.core;bundle-version="1.5.0",
- org.eclipse.emf.ecore.xmi;bundle-version="2.9.0"
+ org.eclipse.emf.ecore.xmi;bundle-version="2.9.0",
+ org.eclipse.viatra.examples.cps.xform.m2m.launcher;bundle-version="0.1.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: org.apache.log4j;version="1.2.15"

--- a/tests/com.incquerylabs.examples.cps.performance.tests/src/com/incquerylabs/examples/cps/performance/tests/BasicXformTest.xtend
+++ b/tests/com.incquerylabs.examples.cps.performance.tests/src/com/incquerylabs/examples/cps/performance/tests/BasicXformTest.xtend
@@ -15,7 +15,7 @@ import java.util.Random
 import com.incquerylabs.examples.cps.performance.tests.config.GeneratorType
 import com.incquerylabs.examples.cps.performance.tests.config.cases.BenchmarkCase
 import com.incquerylabs.examples.cps.performance.tests.config.scenarios.BasicXformScenario
-import org.eclipse.viatra.examples.cps.xform.m2m.tests.wrappers.TransformationType
+import org.eclipse.viatra.examples.cps.xform.m2m.launcher.TransformationType
 
 abstract class BasicXformTest extends PropertiesBasedTest {
 	

--- a/tests/com.incquerylabs.examples.cps.performance.tests/src/com/incquerylabs/examples/cps/performance/tests/CPSPerformanceTest.xtend
+++ b/tests/com.incquerylabs.examples.cps.performance.tests/src/com/incquerylabs/examples/cps/performance/tests/CPSPerformanceTest.xtend
@@ -14,7 +14,7 @@ package com.incquerylabs.examples.cps.performance.tests
 import com.incquerylabs.examples.cps.performance.tests.config.GeneratorType
 import eu.mondo.sam.core.scenarios.BenchmarkScenario
 import java.util.Random
-import org.eclipse.viatra.examples.cps.xform.m2m.tests.wrappers.TransformationType
+import org.eclipse.viatra.examples.cps.xform.m2m.launcher.TransformationType
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized

--- a/tests/com.incquerylabs.examples.cps.performance.tests/src/com/incquerylabs/examples/cps/performance/tests/InstanceModelTest.xtend
+++ b/tests/com.incquerylabs.examples.cps.performance.tests/src/com/incquerylabs/examples/cps/performance/tests/InstanceModelTest.xtend
@@ -12,7 +12,7 @@
 package com.incquerylabs.examples.cps.performance.tests
 
 import org.eclipse.viatra.examples.cps.xform.m2m.tests.CPS2DepTest
-import org.eclipse.viatra.examples.cps.xform.m2m.tests.wrappers.CPSTransformationWrapper
+import org.eclipse.viatra.examples.cps.xform.m2m.launcher.CPSTransformationWrapper
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/tests/com.incquerylabs.examples.cps.performance.tests/src/com/incquerylabs/examples/cps/performance/tests/PropertiesBasedTest.xtend
+++ b/tests/com.incquerylabs.examples.cps.performance.tests/src/com/incquerylabs/examples/cps/performance/tests/PropertiesBasedTest.xtend
@@ -15,7 +15,7 @@ import com.google.common.collect.ImmutableSet
 import com.google.common.collect.Sets
 import com.incquerylabs.examples.cps.performance.tests.config.GeneratorType
 import org.eclipse.viatra.examples.cps.tests.util.PropertiesUtil
-import org.eclipse.viatra.examples.cps.xform.m2m.tests.wrappers.TransformationType
+import org.eclipse.viatra.examples.cps.xform.m2m.launcher.TransformationType
 import org.junit.runners.Parameterized.Parameters
 
 abstract class PropertiesBasedTest extends CPSPerformanceTest {

--- a/tests/com.incquerylabs.examples.cps.performance.tests/src/com/incquerylabs/examples/cps/performance/tests/ScenarioBenchmarkingBase.xtend
+++ b/tests/com.incquerylabs.examples.cps.performance.tests/src/com/incquerylabs/examples/cps/performance/tests/ScenarioBenchmarkingBase.xtend
@@ -24,8 +24,8 @@ import java.util.Random
 import org.apache.log4j.Logger
 import org.eclipse.core.runtime.Platform
 import org.eclipse.viatra.examples.cps.tests.util.CPSTestBase
-import org.eclipse.viatra.examples.cps.xform.m2m.tests.wrappers.CPSTransformationWrapper
-import org.eclipse.viatra.examples.cps.xform.m2m.tests.wrappers.TransformationType
+import org.eclipse.viatra.examples.cps.xform.m2m.launcher.CPSTransformationWrapper
+import org.eclipse.viatra.examples.cps.xform.m2m.launcher.TransformationType
 import org.eclipse.viatra.query.runtime.ViatraQueryRuntimePlugin
 import org.junit.After
 import org.junit.AfterClass

--- a/tests/com.incquerylabs.examples.cps.performance.tests/src/com/incquerylabs/examples/cps/performance/tests/ToolchainPerformanceTest.xtend
+++ b/tests/com.incquerylabs.examples.cps.performance.tests/src/com/incquerylabs/examples/cps/performance/tests/ToolchainPerformanceTest.xtend
@@ -16,7 +16,7 @@ import com.incquerylabs.examples.cps.performance.tests.config.GeneratorType
 import com.incquerylabs.examples.cps.performance.tests.config.cases.BenchmarkCase
 import com.incquerylabs.examples.cps.performance.tests.config.scenarios.ToolChainPerformanceBatchScenario
 import com.incquerylabs.examples.cps.performance.tests.config.scenarios.ToolChainPerformanceIncrementalScenario
-import org.eclipse.viatra.examples.cps.xform.m2m.tests.wrappers.TransformationType
+import org.eclipse.viatra.examples.cps.xform.m2m.launcher.TransformationType
 
 abstract class ToolchainPerformanceTest extends PropertiesBasedTest {
 	

--- a/tests/com.incquerylabs.examples.cps.performance.tests/src/com/incquerylabs/examples/cps/performance/tests/benchmarks/BasicXformAdvancedClientServerTest.xtend
+++ b/tests/com.incquerylabs.examples.cps.performance.tests/src/com/incquerylabs/examples/cps/performance/tests/benchmarks/BasicXformAdvancedClientServerTest.xtend
@@ -14,7 +14,7 @@ package com.incquerylabs.examples.cps.performance.tests.benchmarks
 import java.util.Random
 import com.incquerylabs.examples.cps.performance.tests.config.GeneratorType
 import com.incquerylabs.examples.cps.performance.tests.config.cases.AdvancedClientServerCase
-import org.eclipse.viatra.examples.cps.xform.m2m.tests.wrappers.TransformationType
+import org.eclipse.viatra.examples.cps.xform.m2m.launcher.TransformationType
 
 class BasicXformAdvancedClientServerTest extends com.incquerylabs.examples.cps.performance.tests.BasicXformTest {
 	

--- a/tests/com.incquerylabs.examples.cps.performance.tests/src/com/incquerylabs/examples/cps/performance/tests/benchmarks/BasicXformClientServerTest.xtend
+++ b/tests/com.incquerylabs.examples.cps.performance.tests/src/com/incquerylabs/examples/cps/performance/tests/benchmarks/BasicXformClientServerTest.xtend
@@ -15,7 +15,7 @@ import com.incquerylabs.examples.cps.performance.tests.BasicXformTest
 import com.incquerylabs.examples.cps.performance.tests.config.GeneratorType
 import com.incquerylabs.examples.cps.performance.tests.config.cases.ClientServerCase
 import java.util.Random
-import org.eclipse.viatra.examples.cps.xform.m2m.tests.wrappers.TransformationType
+import org.eclipse.viatra.examples.cps.xform.m2m.launcher.TransformationType
 
 class BasicXformClientServerTest extends BasicXformTest {
 	

--- a/tests/com.incquerylabs.examples.cps.performance.tests/src/com/incquerylabs/examples/cps/performance/tests/benchmarks/BasicXformLowSynchTest.xtend
+++ b/tests/com.incquerylabs.examples.cps.performance.tests/src/com/incquerylabs/examples/cps/performance/tests/benchmarks/BasicXformLowSynchTest.xtend
@@ -15,7 +15,7 @@ import com.incquerylabs.examples.cps.performance.tests.BasicXformTest
 import com.incquerylabs.examples.cps.performance.tests.config.GeneratorType
 import com.incquerylabs.examples.cps.performance.tests.config.cases.LowSynchCase
 import java.util.Random
-import org.eclipse.viatra.examples.cps.xform.m2m.tests.wrappers.TransformationType
+import org.eclipse.viatra.examples.cps.xform.m2m.launcher.TransformationType
 
 class BasicXformLowSynchTest extends BasicXformTest {
 	

--- a/tests/com.incquerylabs.examples.cps.performance.tests/src/com/incquerylabs/examples/cps/performance/tests/benchmarks/BasicXformPublishSubscribeTest.xtend
+++ b/tests/com.incquerylabs.examples.cps.performance.tests/src/com/incquerylabs/examples/cps/performance/tests/benchmarks/BasicXformPublishSubscribeTest.xtend
@@ -15,7 +15,7 @@ import com.incquerylabs.examples.cps.performance.tests.BasicXformTest
 import com.incquerylabs.examples.cps.performance.tests.config.GeneratorType
 import com.incquerylabs.examples.cps.performance.tests.config.cases.PublishSubscribeCase
 import java.util.Random
-import org.eclipse.viatra.examples.cps.xform.m2m.tests.wrappers.TransformationType
+import org.eclipse.viatra.examples.cps.xform.m2m.launcher.TransformationType
 
 class BasicXformPublishSubscribeTest extends BasicXformTest {
 	

--- a/tests/com.incquerylabs.examples.cps.performance.tests/src/com/incquerylabs/examples/cps/performance/tests/benchmarks/BasicXformSimpleScalingTest.xtend
+++ b/tests/com.incquerylabs.examples.cps.performance.tests/src/com/incquerylabs/examples/cps/performance/tests/benchmarks/BasicXformSimpleScalingTest.xtend
@@ -15,7 +15,7 @@ import com.incquerylabs.examples.cps.performance.tests.BasicXformTest
 import com.incquerylabs.examples.cps.performance.tests.config.GeneratorType
 import com.incquerylabs.examples.cps.performance.tests.config.cases.SimpleScalingCase
 import java.util.Random
-import org.eclipse.viatra.examples.cps.xform.m2m.tests.wrappers.TransformationType
+import org.eclipse.viatra.examples.cps.xform.m2m.launcher.TransformationType
 
 class BasicXformSimpleScalingTest extends BasicXformTest {
 	

--- a/tests/com.incquerylabs.examples.cps.performance.tests/src/com/incquerylabs/examples/cps/performance/tests/benchmarks/CPSDemonstratorIntegrationTest.xtend
+++ b/tests/com.incquerylabs.examples.cps.performance.tests/src/com/incquerylabs/examples/cps/performance/tests/benchmarks/CPSDemonstratorIntegrationTest.xtend
@@ -27,7 +27,7 @@ import org.eclipse.viatra.examples.cps.generator.dtos.CPSGeneratorInput
 import org.eclipse.viatra.examples.cps.planexecutor.PlanExecutor
 import org.eclipse.viatra.examples.cps.traceability.TraceabilityFactory
 import org.eclipse.viatra.examples.cps.xform.m2m.tests.CPS2DepTest
-import org.eclipse.viatra.examples.cps.xform.m2m.tests.wrappers.CPSTransformationWrapper
+import org.eclipse.viatra.examples.cps.xform.m2m.launcher.CPSTransformationWrapper
 import org.eclipse.viatra.examples.cps.xform.m2t.api.ChangeM2TOutputProvider
 import org.eclipse.viatra.examples.cps.xform.m2t.api.DefaultM2TOutputProvider
 import org.eclipse.viatra.examples.cps.xform.m2t.distributed.CodeGenerator

--- a/tests/com.incquerylabs.examples.cps.performance.tests/src/com/incquerylabs/examples/cps/performance/tests/benchmarks/ToolchainPerformanceStatisticsBasedTest.xtend
+++ b/tests/com.incquerylabs.examples.cps.performance.tests/src/com/incquerylabs/examples/cps/performance/tests/benchmarks/ToolchainPerformanceStatisticsBasedTest.xtend
@@ -15,7 +15,7 @@ import com.incquerylabs.examples.cps.performance.tests.ToolchainPerformanceTest
 import com.incquerylabs.examples.cps.performance.tests.config.GeneratorType
 import com.incquerylabs.examples.cps.performance.tests.config.cases.StatisticBasedCase
 import java.util.Random
-import org.eclipse.viatra.examples.cps.xform.m2m.tests.wrappers.TransformationType
+import org.eclipse.viatra.examples.cps.xform.m2m.launcher.TransformationType
 
 class ToolchainPerformanceStatisticsBasedTest extends ToolchainPerformanceTest {
 	

--- a/tests/com.incquerylabs.examples.cps.performance.tests/src/com/incquerylabs/examples/cps/performance/tests/config/CPSDataToken.xtend
+++ b/tests/com.incquerylabs.examples.cps.performance.tests/src/com/incquerylabs/examples/cps/performance/tests/config/CPSDataToken.xtend
@@ -14,8 +14,8 @@ package com.incquerylabs.examples.cps.performance.tests.config
 import eu.mondo.sam.core.DataToken
 import org.eclipse.core.resources.IFolder
 import org.eclipse.viatra.examples.cps.traceability.CPSToDeployment
-import org.eclipse.viatra.examples.cps.xform.m2m.tests.wrappers.CPSTransformationWrapper
-import org.eclipse.viatra.examples.cps.xform.m2m.tests.wrappers.TransformationType
+import org.eclipse.viatra.examples.cps.xform.m2m.launcher.CPSTransformationWrapper
+import org.eclipse.viatra.examples.cps.xform.m2m.launcher.TransformationType
 import org.eclipse.viatra.examples.cps.xform.m2t.api.ICPSGenerator
 import org.eclipse.viatra.examples.cps.xform.m2t.monitor.DeploymentChangeMonitor
 import org.eclipse.xtend.lib.annotations.Accessors

--- a/tests/com.incquerylabs.examples.cps.performance.tests/src/com/incquerylabs/examples/cps/performance/tests/config/phases/GenerationPhase.xtend
+++ b/tests/com.incquerylabs.examples.cps.performance.tests/src/com/incquerylabs/examples/cps/performance/tests/config/phases/GenerationPhase.xtend
@@ -17,7 +17,7 @@ import eu.mondo.sam.core.metrics.TimeMetric
 import org.eclipse.viatra.examples.cps.generator.CPSPlanBuilder
 import org.eclipse.viatra.examples.cps.generator.dtos.CPSFragment
 import org.eclipse.viatra.examples.cps.generator.dtos.CPSGeneratorInput
-import org.eclipse.viatra.examples.cps.generator.interfaces.ICPSConstraints
+import org.eclipse.viatra.examples.cps.generator.dtos.constraints.ICPSConstraints
 import org.eclipse.viatra.examples.cps.generator.utils.StatsUtil
 import org.eclipse.viatra.examples.cps.planexecutor.PlanExecutor
 

--- a/tests/com.incquerylabs.examples.cps.performance.tests/src/com/incquerylabs/examples/cps/performance/tests/config/phases/StatisticsBasedGenerationPhase.xtend
+++ b/tests/com.incquerylabs.examples.cps.performance.tests/src/com/incquerylabs/examples/cps/performance/tests/config/phases/StatisticsBasedGenerationPhase.xtend
@@ -12,7 +12,7 @@
 package com.incquerylabs.examples.cps.performance.tests.config.phases
 
 import org.eclipse.viatra.examples.cps.generator.CPSPlanBuilder
-import org.eclipse.viatra.examples.cps.generator.interfaces.ICPSConstraints
+import org.eclipse.viatra.examples.cps.generator.dtos.constraints.ICPSConstraints
 
 class StatisticsBasedGenerationPhase extends GenerationPhase {
 


### PR DESCRIPTION
[518585] Update references after moving CPS transformation wrappers
The change https://git.eclipse.org/r/100849 moves CPS transformation
wrappers to cps.xform.m2m.launcher project.

[519174] Update references after moving ICPSConstraints
The change https://git.eclipse.org/r/100725 moves the ICPSConstraints
interface to cps.generator.dtos.constraints package.
