### PR TITLE
[releng] Updates benchmark configuration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
     booleanParam(defaultValue: false, description: 'Set to true if you don\'t want to run the CPS build.', name: 'SKIP_CPS')
     booleanParam(defaultValue: false, description: 'Set to true if you don\'t want to run the benchmark build', name: 'SKIP_BUILD')
     booleanParam(defaultValue: false, description: 'Set to true if you don\'t want to run the benchmark', name: 'SKIP_BENCHMARK')
-    string(defaultValue: '2.1.0-SNAPSHOT', description: '', name: 'VIATRA_COMPILER_VERSION')
+    string(defaultValue: '2.2.0-SNAPSHOT', description: '', name: 'VIATRA_COMPILER_VERSION')
     string(defaultValue: 'https://build.incquerylabs.com/jenkins/job/VIATRA2-EMF-Core/lastSuccessfulBuild/artifact/releng/org.eclipse.viatra.update/target/repository/', description: 'VIATRA Update site with the benchmarked version.', name: 'VIATRA_REPOSITORY_URL')
     choice(choices: 'ci\nm2m-reduced\nm2m-lowsynch\nm2m\ntoolchain', description: 'Select the benchmark configuration to run (scenarios, cases, tools, etc.)', name: 'BENCHMARK_CONFIG')
     text(defaultValue: 'Measure performance of latest master build', description: 'You may add information on why this benchmark is relevant and include URLs (e.g. Gerrit change including patch version) to ease historical analyis of results.', name: 'BENCHMARK_DESCRIPTION')

--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,8 @@
 		<module>releng/com.incquerylabs.examples.cps.rcpapplication.headless</module>
 	</modules>
 	<properties>
-		<tycho.version>1.0.0</tycho.version>
-		<xtend.compiler.version>2.13.0</xtend.compiler.version>
+		<tycho.version>1.3.0</tycho.version>
+		<xtend.compiler.version>2.16.0</xtend.compiler.version>
 		<viatra.repository.url>http://download.eclipse.org/viatra/updates/integration</viatra.repository.url>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
@@ -160,13 +160,6 @@
 					<groupId>org.eclipse.xtend</groupId>
 					<artifactId>xtend-maven-plugin</artifactId>
 					<version>${xtend.compiler.version}</version>
-					<dependencies>
-                        <dependency>
-                            <groupId>org.eclipse.platform</groupId>
-                            <artifactId>org.eclipse.equinox.common</artifactId>
-                            <version>3.10.0</version>
-                        </dependency>
-                    </dependencies>
 					<configuration>
 						<!-- need to prefix by basedir to generate to currently built module -->
 						<outputDirectory>${basedir}/xtend-gen</outputDirectory>

--- a/releng/com.incquerylabs.examples.cps.target/com.incquerylabs.examples.cps.target.target
+++ b/releng/com.incquerylabs.examples.cps.target/com.incquerylabs.examples.cps.target.target
@@ -4,15 +4,15 @@
   <locations>
   	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
       <unit id="com.google.inject.multibindings" version="3.0.0.v201402270930"/>
-      <unit id="org.eclipse.emf.sdk.feature.group" version="2.13.0.v20170504-0807"/>
+      <unit id="org.eclipse.emf.sdk.feature.group" version="2.13.0.v20170609-0928"/>
       <unit id="org.eclipse.emf.transaction.feature.group" version="1.11.0.201706061339"/>
-      <unit id="org.eclipse.equinox.sdk.feature.group" version="3.13.0.v20170531-1133"/>
-      <unit id="org.eclipse.sdk.feature.group" version="4.7.0.v20170531-2000"/>
-      <repository location="http://download.eclipse.org/releases/oxygen/201706091000"/>
+      <unit id="org.eclipse.equinox.sdk.feature.group" version="3.13.4.v20180322-2228"/>
+      <unit id="org.eclipse.sdk.feature.group" version="4.7.3.v20180330-0919"/>
+      <repository location="http://download.eclipse.org/releases/oxygen/201804111000"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-      <unit id="org.eclipse.xtext.sdk.feature.group" version="2.13.0.v20171020-0920"/>
-      <repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.13.0"/>
+      <unit id="org.eclipse.xtext.sdk.feature.group" version="2.16.0.v20181203-1555"/>
+      <repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.16.0"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
       <unit id="org.apache.commons.io" version="2.2.0.v201405211200"/>


### PR DESCRIPTION
VIATRA 2.2 requires Xtext 2.16 and Oxygen as a minimum target platform
(was tracked in https://bugs.eclipse.org/bugs/show_bug.cgi?id=543220),
so we should increase the dependencies used by the benchmark application
to a version that all 2.x VIATRA versions support.